### PR TITLE
Add post-reducer feature unit tests

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/__tests__/AddPostForm.test.js
+++ b/frontend/src/__tests__/AddPostForm.test.js
@@ -1,0 +1,31 @@
+import postsReducer, { postAdded } from "../slices/postSlice";
+
+describe("postsReducer", () => {
+  const initialState = [];
+
+  it("should handle initial state", () => {
+    expect(postsReducer(undefined, { type: undefined })).toEqual(initialState);
+  });
+
+  it("should handle postAdded", () => {
+    const title = "Test Post";
+    const content = "Test content";
+    const postVisibility = "public";
+
+    const action = postAdded({
+      title,
+      content,
+      postVisibility,
+    });
+    const result = postsReducer(initialState, action);
+
+    expect(result.length).toBe(1);
+    // FIXME: In the postAdded return value below,
+    // title and others are passed as objects wrapped inside title. Should be enhanced.
+    expect(result[0].title.title).toEqual(title);
+    expect(result[0].title.content).toEqual(content);
+    expect(result[0].title.postVisibility).toEqual(postVisibility);
+    expect(result[0]).toHaveProperty("timestamp");
+    expect(result[0]).toHaveProperty("postId");
+  });
+});


### PR DESCRIPTION
- Testing the Post Add feature as part of unit testing
- As noted in the FIXME comment, the Post data in the return value of the PostAdded slicer is wrapped in the Title as an object. This seems to need to be improved.
<img width="789" alt="image" src="https://github.com/hendrik-kim/blog-mern/assets/48870515/83157b90-97a8-41b8-9207-2721a2498e98">
